### PR TITLE
README: pod install with --repo-update flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ BitBot and I are not associated or affiliated with Bitrise in any way.
 
 ### Building
 - Clone the repo
-- Run `pod install` in the root directory
+- Run `pod install --repo-update` in the root directory
 - Open Bitrise.xcworkspace file
 - Build Bitrise target or export binary
 


### PR DESCRIPTION
Added the `--repo-update` flag to the `pod install` command in the README, otherwise you might end up with an error like:

```
$ pod install                                                                                                                                                                      

Analyzing dependencies
[!] CocoaPods could not find compatible versions for pod "EasyMapping":
  In snapshot (Podfile.lock):
    EasyMapping (= 0.22.0)

  In Podfile:
    EasyMapping

None of your spec sources contain a spec satisfying the dependencies: `EasyMapping, EasyMapping (= 0.22.0)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```