### PR TITLE
Add open in Browser when click in build

### DIFF
--- a/Bitrise/Controller/BRMainController.m
+++ b/Bitrise/Controller/BRMainController.m
@@ -13,13 +13,14 @@
 #import "BRAccountsViewController.h"
 
 #import "BRSyncCommand.h"
+#import "BRBuildInfo.h"
 #import "BRBuildStateInfo.h"
 #import "BRSettingsMenuController.h"
 #import "BRBuildMenuController.h"
 #import "BRLogsTextViewController.h"
 #import "BRSegue.h"
 #import "BRLogsWindowPresenter.h"
-
+#import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSUInteger, BRBuildMenuItem) {
     BRBuildMenuItemUndefined = 0,
@@ -77,6 +78,17 @@ typedef NS_ENUM(NSUInteger, BRBuildMenuItem) {
         }
     }];
     
+    
+    [self.dataSource setNavigationCallback:^(BRAppsDataSourceNavigationAction action, BRBuild *build) {
+        switch (action) {
+            case BRAppsDataSourceNavigationActionOpenInBrowser:
+                [weakSelf openBuild:build];
+                break;
+                
+            default: break;
+        }
+    }];
+    
     self.buildController = [[BRBuildMenuController alloc] initWithAPI:[self.dependencyContainer bitriseAPI]
                                                            syncEngine:self.syncEngine
                                                           logObserver:[self.dependencyContainer logObserver]
@@ -111,6 +123,14 @@ typedef NS_ENUM(NSUInteger, BRBuildMenuItem) {
 - (IBAction)openSettingsMenu:(NSButton *)sender {
     NSPoint point = NSMakePoint(0.0, sender.bounds.size.height + 5.0);
     [self.settingsMenu popUpMenuPositioningItem:nil atLocation:point inView:sender];
+}
+
+- (void) openBuild:(BRBuild *)build {
+    BRBuildInfo *buildInfo = [[BRBuildInfo alloc] initWithBuild:build];
+    NSString *stringUrl = [NSString stringWithFormat:@"%@/build/%@",self.environment.baseUrlBitriseApp,buildInfo.slug];
+    NSURL *url = [NSURL URLWithString:stringUrl];
+    [[NSWorkspace sharedWorkspace] openURL: url];
+    [[[NSApplication sharedApplication] windows].lastObject close];
 }
 
 @end

--- a/Bitrise/Environment/BREnvironment.h
+++ b/Bitrise/Environment/BREnvironment.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Info -
 - (NSString *)versionNumber;
 - (NSString *)buildNumber;
+- (NSString *)baseUrlBitriseApp;
 
 #pragma mark - Notifications -
 

--- a/Bitrise/Environment/BREnvironment.m
+++ b/Bitrise/Environment/BREnvironment.m
@@ -10,6 +10,7 @@
 
 static NSString * const kBRNotificationsKey = @"kBRNotificationsKey";
 static NSString * const kBRFirstLaunchKey = @"kBRFirstLaunchKey";
+static NSString * const kBRBaseUrlBitriseApp = @"https://app.bitrise.io";
 
 @interface BREnvironment ()
 
@@ -43,6 +44,10 @@ static NSString * const kBRFirstLaunchKey = @"kBRFirstLaunchKey";
 
 - (NSString *)buildNumber {
     return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+}
+
+- (NSString *)baseUrlBitriseApp {
+    return kBRBaseUrlBitriseApp;
 }
 
 #pragma mark - Notifications -

--- a/Bitrise/Storage/Data Sources/BRAppsDataSource.h
+++ b/Bitrise/Storage/Data Sources/BRAppsDataSource.h
@@ -12,7 +12,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, BRAppsDataSourceNavigationAction) {
+    BRAppsDataSourceNavigationActionUndefined = 0,
+    BRAppsDataSourceNavigationActionOpenInBrowser
+};
+
 @interface BRAppsDataSource : NSObject <NSOutlineViewDataSource, NSOutlineViewDelegate>
+
+@property (copy, nonatomic) void (^navigationCallback)(BRAppsDataSourceNavigationAction, BRBuild*);
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithContainer:(NSPersistentContainer *)container cellBuilder:(BRCellBuilder *)cellBuilder  NS_DESIGNATED_INITIALIZER;

--- a/Bitrise/Storage/Data Sources/BRAppsDataSource.m
+++ b/Bitrise/Storage/Data Sources/BRAppsDataSource.m
@@ -11,6 +11,7 @@
 #import <CoreData/CoreData.h>
 
 #import "BRLogger.h"
+#import "BRMacro.h"
 
 #import "BRAppCellView.h"
 #import "BRBuildCellView.h"
@@ -92,6 +93,11 @@
 
 - (NSTableRowView *)outlineView:(NSOutlineView *)outlineView rowViewForItem:(id)item {
     return [self.cellBuilder buildCell:item forOutline:outlineView];
+}
+
+- (BOOL)outlineView:(NSOutlineView *)outlineView shouldSelectItem:(id)item {
+    BR_SAFE_CALL(self.navigationCallback, BRAppsDataSourceNavigationActionOpenInBrowser, item);
+    return YES;
 }
 
 #pragma mark - NSFetchedResultsControllerDelegate -


### PR DESCRIPTION
This PR add open in Browser when click in build feature.

I created a callback property in datasource to run actions in MainViewController, for first, open in browser when click, to user can go to the build in browser, in the future, features like abort build can be implemented using this methods.

![2020-03-02 13 07 19](https://user-images.githubusercontent.com/8092922/75694188-e2488d00-5c86-11ea-91a8-58f65082acf2.gif)
