### PR TITLE
Vertically centered build status icon

### DIFF
--- a/Bitrise/View/Base.lproj/Main.storyboard
+++ b/Bitrise/View/Base.lproj/Main.storyboard
@@ -814,7 +814,7 @@
                                                                                         <constraint firstItem="Idm-IL-eUs" firstAttribute="leading" secondItem="Mv7-pf-SlE" secondAttribute="leading" id="Qx4-Nj-N4c"/>
                                                                                         <constraint firstAttribute="height" constant="90" id="SWu-Dh-xDB"/>
                                                                                         <constraint firstItem="Nvh-D2-Lrc" firstAttribute="leading" secondItem="Mv7-pf-SlE" secondAttribute="leading" id="dFR-7n-5AG"/>
-                                                                                        <constraint firstItem="Idm-IL-eUs" firstAttribute="centerY" secondItem="Mv7-pf-SlE" secondAttribute="centerY" constant="-10" id="jhn-eD-5uR"/>
+                                                                                        <constraint firstItem="Idm-IL-eUs" firstAttribute="centerY" secondItem="Mv7-pf-SlE" secondAttribute="centerY" id="jhn-eD-5uR"/>
                                                                                         <constraint firstAttribute="trailing" secondItem="Idm-IL-eUs" secondAttribute="trailing" id="umV-zK-4CQ"/>
                                                                                     </constraints>
                                                                                 </customView>


### PR DESCRIPTION
Here's how build status icons look like before the fix, they have an offset of 10 points wrt the vertical center:
![Screen Shot 2020-08-31 at 16 32 16](https://user-images.githubusercontent.com/531755/91731989-e4dd5e00-eba7-11ea-9eaa-8bc4182b1dbf.png)

After the fix:
![Screen Shot 2020-08-31 at 16 39 18](https://user-images.githubusercontent.com/531755/91732524-a3997e00-eba8-11ea-932b-c7df07f9341c.png)
